### PR TITLE
Fix trigger event check

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,7 @@ runs:
       id: duration
       with:
         script: |
+          console.log(context.eventName)
           if (context.eventName != 'pull_request') {
             proccess.exit(0)
           }

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ runs:
         script: |
           console.log(context.eventName)
           if (context.eventName != 'pull_request') {
-            proccess.exit(0)
+            return
           }
           const currentTime = new Date().getTime();
           const currentRun = await github.rest.actions.getWorkflowRun({

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,6 @@ runs:
       id: duration
       with:
         script: |
-          console.log(context.eventName)
           if (context.eventName != 'pull_request') {
             return
           }


### PR DESCRIPTION
Using `process.exit(0)` failed since `process` was unknown. 

Logs from failed run here: https://github.com/DeviesDevelopment/frontman/actions/runs/2109581056

I re-tagged `795cd73e9330d389b9c599887af08fe27cad708b` to `v0.0.2` so that I could re-trigger the updated action from `master` in frontman. 

Here are the logs of the successful log that show that `return` works.  https://github.com/DeviesDevelopment/frontman/actions/runs/2188705303

The master on Frontman is now green since I manually re-triggered the jobs so that they used the updated version v0.0.2 of workflow-timer. 

When this PR is merged we can retag the latest commit on master with `v0.0.2` and create the new release. 