### PR TITLE
feat: update existing comments if they exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ As the **very last job** in your workflow, add
 - name: Time reporter
   uses: DeviesDevelopment/workflow-timer@v0.0.2
 ```
+
 Workflow-timer compares the current workflow run with the latest run on the master/main branch. Therefore, the same workflow needs to run when merging with the master as well, otherwise, there will be no data to compare. We suggest having the following definition in the workflow:
 
-```
+```yaml
 on:
   push:
     branches: master
@@ -27,4 +28,5 @@ on:
 ```
 
 ## How to contribute
+
 Feel free to open a pull request! All contributions, no matter how small, are more than welcome. Happy hacking!

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,7 @@ runs:
           if (context.eventName != 'pull_request') {
             return
           }
+
           const currentTime = new Date().getTime();
           const currentRun = await github.rest.actions.getWorkflowRun({
             owner: context.repo.owner,
@@ -37,7 +38,7 @@ runs:
             x.conclusion == 'success'
           );
 
-          var outputMessage = ''
+          let outputMessage = ''
           if (latestRunsOnMaster.length === 0) {
             outputMessage = "No data for historical runs on master/main branch found. Can't compare."
           } else {
@@ -50,13 +51,13 @@ runs:
             outputMessage =  '🕒 Workflow \"' + context.workflow + '\" took ' +  (currentRunDurationInMillis / 1000) + 's which is ' + outcome + ' with ' + Math.abs(diffInSeconds) + 's (' + Math.abs(percentageDiff) + '%) compared to latest run on master/main.'
           }
 
-          var commentData = {
+          const commentData = {
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: context.issue.number,
           };
 
-          var comments = github.rest.issues.listComments(commentData);
+          const comments = await github.rest.issues.listComments(commentData);
 
           /**
           * Add the body content after comments are fetched so that it's
@@ -68,7 +69,7 @@ runs:
           * Search comments from the bottom-up to find the most recent comment
           * from the GitHub Actions bot that matches our criteria.
           */
-          var existingComment = comments.reverse().find(comment => {
+          const existingComment = comments.reverse().find(comment => {
             return (
               comment?.user?.login === 'github-actions[bot]' &&
               comment?.user?.type === "Bot" &&
@@ -77,10 +78,10 @@ runs:
           })
 
           // If the comment exists then update instead of creating a new one.
-          var action = existingComment ? "updateComment" : "createComment";
+          const action = existingComment ? "updateComment" : "createComment";
 
           if (existingComment) {
               commentData.comment_id = existingComment.id;
           }
 
-          github.rest.issues[action](commentData);
+          await github.rest.issues[action](commentData);

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
           });
           const startedAt = currentRun.data.run_started_at
           const currentRunDurationInMillis = currentTime - new Date(startedAt).getTime();
-          
+
           const workflowId = currentRun.data.workflow_id
           const historical_runs = await github.rest.actions.listWorkflowRuns({
             owner: context.repo.owner,
@@ -46,13 +46,41 @@ runs:
             const diffInSeconds = (currentRunDurationInMillis - latestMasterRunDurationInMillis) / 1000
             const percentageDiff = ((1 - (currentRunDurationInMillis/latestMasterRunDurationInMillis)) * 100).toFixed(2)
             const outcome = (diffInSeconds > 0) ? "an increase" : "a decrease"
-         
+
             outputMessage =  '🕒 Workflow \"' + context.workflow + '\" took ' +  (currentRunDurationInMillis / 1000) + 's which is ' + outcome + ' with ' + Math.abs(diffInSeconds) + 's (' + Math.abs(percentageDiff) + '%) compared to latest run on master/main.'
           }
 
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
+          var commentData = {
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: outputMessage
+            issue_number: context.issue.number,
+          };
+
+          var comments = github.rest.issues.listComments(commentData);
+
+          /**
+          * Add the body content after comments are fetched so that it's
+          * not included in the search for existing comments.
+          */
+          commentData.body = outputMessage;
+
+          /**
+          * Search comments from the bottom-up to find the most recent comment
+          * from the GitHub Actions bot that matches our criteria.
+          */
+          var existingComment = comments.reverse().find(comment => {
+            return (
+              comment?.user?.login === 'github-actions[bot]' &&
+              comment?.user?.type === "Bot" &&
+              comment?.body?.startsWith('🕒 Workflow \"')
+              );
           })
+
+          // If the comment exists then update instead of creating a new one.
+          var action = existingComment ? "updateComment" : "createComment";
+
+          if (existingComment) {
+              commentData.comment_id = existingComment.id;
+          }
+
+          github.rest.issues[action](commentData);


### PR DESCRIPTION
This update relates to issue #7 to update existing comments in a pull request on subsequent runs. In larger repos, this will reduce the amount of comments being added to a PR during its review cycle.