### PR TITLE
Add workflow to check state of diff folder

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -19,7 +19,6 @@ permissions:
 
 jobs:
   check-dist:
-    name: Check dist/
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -1,0 +1,59 @@
+# In TypeScript actions, `dist/` is a special directory. When you reference
+# an action with the `uses:` property, `dist/index.js` is the code that will be
+# run. For this project, the `dist/index.js` file is transpiled from other
+# source files. This workflow ensures the `dist/` directory contains the
+# expected transpiled code.
+#
+# If this workflow is run from a feature branch, it will act as an additional CI
+# check and fail if the checked-in `dist/` directory does not match what is
+# expected from the build.
+name: Check Transpiled JavaScript
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  check-dist:
+    name: Check dist/
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        id: setup-node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install Dependencies
+        id: install
+        run: npm ci
+
+      - name: Build dist/ Directory
+        id: build
+        run: npm run bundle
+
+      # This will fail the workflow if the `dist/` directory is different than
+      # expected.
+      - name: Compare Directories
+        id: diff
+        run: |
+          if [ ! -d dist/ ]; then
+            echo "Expected dist/ directory does not exist.  See status below:"
+            ls -la ./
+            exit 1
+          fi
+          if [ "$(git diff --ignore-space-at-eol --text dist/ | wc -l)" -gt "0" ]; then
+            echo "Detected uncommitted changes after build. See status below:"
+            git diff --ignore-space-at-eol --text dist/
+            exit 1
+          fi

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -7,7 +7,7 @@
 # If this workflow is run from a feature branch, it will act as an additional CI
 # check and fail if the checked-in `dist/` directory does not match what is
 # expected from the build.
-name: Check Transpiled JavaScript
+name: check-dist
 
 on:
   pull_request:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "node": ">=20"
   },
   "scripts": {
+    "bundle": "npm run format:write && npm run package",
     "format:write": "npx prettier --write .",
     "format:check": "npx prettier --check .",
     "lint": "npx eslint .",

--- a/src/commentManager.ts
+++ b/src/commentManager.ts
@@ -6,7 +6,7 @@ export function previousCommentFor(workflowName: string) {
     body?: string
   }) => {
     return (
-      comment.user?.login === 'github-actions[botzzz]' &&
+      comment.user?.login === 'github-actions[bot]' &&
       comment.user?.type === 'Bot' &&
       comment.body?.startsWith(`🕒 Workflow "${workflowName}"`)
     )

--- a/src/commentManager.ts
+++ b/src/commentManager.ts
@@ -6,7 +6,7 @@ export function previousCommentFor(workflowName: string) {
     body?: string
   }) => {
     return (
-      comment.user?.login === 'github-actions[bot]' &&
+      comment.user?.login === 'github-actions[botzzz]' &&
       comment.user?.type === 'Bot' &&
       comment.body?.startsWith(`🕒 Workflow "${workflowName}"`)
     )


### PR DESCRIPTION
Code changes need to be manually packaged by running `npm run package`.
This workflow verifies that there's no diff to the `dist` folder after packaging the project.